### PR TITLE
feat: change func version following `.func-version` file in a current working directory

### DIFF
--- a/func.js
+++ b/func.js
@@ -16,7 +16,7 @@ async function main() {
     }
 
     const { downloadDir } = await getLocations();
-    
+
     const versionFile = path.join(downloadDir, 'funcvm-core-tools-version.txt');
     const localVersionFile = path.join(process.cwd(), '.func-version');
     let version;
@@ -34,7 +34,7 @@ async function main() {
 
     const funcBin = path.join(downloadDir, version, 'func');
     const funcBinWindows = path.join(downloadDir, version, 'func.exe');
-    
+
     if (!fs.existsSync(funcBin) && !fs.existsSync(funcBinWindows)) {
         console.error(`func binary not found at ${funcBin}. Try running 'funcvm install ${version}' to repair.`);
         process.exit(1);

--- a/func.js
+++ b/func.js
@@ -24,19 +24,7 @@ async function main() {
     if (!!process.env[constants.versionEnvironmentVariableName]) {
         version = process.env[constants.versionEnvironmentVariableName];
     } else if (fs.existsSync(localVersionFile)) {
-        await new Promise((resolve) => {
-          const re = /(\d+\.\d+\.\d+)( already)? installed./;
-          const p = spawn(`funcvm${process.platform === 'win32' ? '.cmd': ''}`, ['install', fs.readFileSync(localVersionFile, 'utf8').trim()]);
-          p.on('exit', (code)=>{
-            resolve(code);
-          });
-          p.stdout.setEncoding('utf-8');
-          p.stdout.on('data', (data)=>{
-            !/\d+\.\d+\.\d+ already installed./.test(data) && process.stdout.write(data);
-            if (re.test(data)) version = data.match(re)[1];
-          });
-        });
-
+        version = fs.readFileSync(localVersionFile, 'utf8').trim();
     } else if (fs.existsSync(versionFile)) {
         version = fs.readFileSync(versionFile, 'utf8');
     } else {

--- a/func.js
+++ b/func.js
@@ -26,7 +26,7 @@ async function main() {
     } else if (fs.existsSync(localVersionFile)) {
         await new Promise((resolve) => {
           const re = /(\d+\.\d+\.\d+)( already)? installed./;
-          const p = spawn('funcvm', ['install', fs.readFileSync(localVersionFile, 'utf8').trim()]);
+          const p = spawn(`funcvm${process.platform === 'win32' ? '.cmd': ''}`, ['install', fs.readFileSync(localVersionFile, 'utf8').trim()]);
           p.on('exit', (code)=>{
             resolve(code);
           });

--- a/index.js
+++ b/index.js
@@ -50,13 +50,10 @@ async function main() {
         }
         for (const version of versions) {
             if (/^\d+\.\d+\.\d+/.test(version) && fs.lstatSync(path.join(downloadDir, version)).isDirectory()) {
-                const suffix = ((v, c, l) => {
-                    if (c === v && l === v) return ' (global, local)';
-                    else if (c === v) return ' (global)';
-                    else if (l === v) return ' (local)';
-                    return '';
-                })(version, currentVersion, localVersion);
-                console.log(`${version}${suffix}`);
+                const tags = [];
+                currentVersion === version && tags.push('global');
+                localVersion === version && tags.push('local');
+                console.log(`${version}${tags.length > 0 ? ` (${tags.join(', ')})`: ''}`);
             }
         }
         process.exit(0);
@@ -128,7 +125,6 @@ Examples:
             tags[tagName] = tagInfo;
         }
     }
-
     let tag = tags[`v${version}`];
 
     if (!tag) {

--- a/index.js
+++ b/index.js
@@ -36,7 +36,6 @@ async function main() {
     const isInstallCommand = command === 'install' && !!version;
     const isListCommand = command === 'list';
     const isRemoveCommand = command === 'remove';
-    const isFreezeCommand = command === 'freeze';
 
     if (isListCommand) {
         const versions = fs.readdirSync(downloadDir);
@@ -59,11 +58,6 @@ async function main() {
         }
         fs.rmdirSync(versionDir, { recursive: true });
         process.exit(0);
-    } else if (isFreezeCommand) {
-        const versionFile = path.join(downloadDir, 'funcvm-core-tools-version.txt');
-        const localVersionFile = path.join(process.cwd(), '.func-version');
-        fs.copyFileSync(versionFile, localVersionFile);
-        process.exit(0);
     } else if (!isUseCommand && !isInstallCommand) {
         console.log(`
 Azure Functions Core Tools Version Manager (unofficial)
@@ -78,6 +72,9 @@ Examples:
     Install and use exact version:
         funcvm use 4.0.3928
         
+    Install and use the version only for the current directory:
+        funcvm use 4.0.3928 --local
+        
     Install exact version:
         funcvm install 4.0.3928
 
@@ -85,10 +82,7 @@ Examples:
         funcvm list
         
     Remove an installed version:
-        funcvm remove 4.0.3928
-
-    Generate \`.func-version\` in current directory:
-        funcvm freeze\n`);
+        funcvm remove 4.0.3928\n`);
         process.exit(0);
     }
 
@@ -177,7 +171,11 @@ Examples:
     }
     
     if (isUseCommand) {
-        fs.writeFileSync(path.join(downloadDir, 'funcvm-core-tools-version.txt'), tag.coreToolsVersion, 'utf8');
+        if (args.includes('--local')) {
+          fs.writeFileSync(path.join(process.cwd(), '.func-version'), tag.coreToolsVersion, 'utf8');
+        } else {
+          fs.writeFileSync(path.join(downloadDir, 'funcvm-core-tools-version.txt'), tag.coreToolsVersion, 'utf8');
+        }
         console.log(`Using ${tag.coreToolsVersion}`);
     }
 }

--- a/index.js
+++ b/index.js
@@ -40,13 +40,23 @@ async function main() {
     if (isListCommand) {
         const versions = fs.readdirSync(downloadDir);
         const versionFile = path.join(downloadDir, 'funcvm-core-tools-version.txt');
-        let currentVersion;
+        const localVersionFile = path.join(process.cwd(), '.func-version');
+        let currentVersion, localVersion;
         if (fs.existsSync(versionFile)) {
             currentVersion = fs.readFileSync(versionFile, 'utf8');
         }
+        if (fs.existsSync(localVersionFile)) {
+            localVersion = fs.readFileSync(localVersionFile, 'utf8');
+        }
         for (const version of versions) {
             if (/^\d+\.\d+\.\d+/.test(version) && fs.lstatSync(path.join(downloadDir, version)).isDirectory()) {
-                console.log(version + (currentVersion === version ? ' (selected)' : ''));
+                const suffix = ((v, c, l) => {
+                    if (c === v && l === v) return ' (global, local)';
+                    else if (c === v) return ' (global)';
+                    else if (l === v) return ' (local)';
+                    return '';
+                })(version, currentVersion, localVersion);
+                console.log(`${version}${suffix}`);
             }
         }
         process.exit(0);
@@ -71,16 +81,16 @@ Examples:
 
     Install and use exact version:
         funcvm use 4.0.3928
-        
+
     Install and use the version only for the current directory:
         funcvm use 4.0.3928 --local
-        
+
     Install exact version:
         funcvm install 4.0.3928
 
     List installed versions:
         funcvm list
-        
+
     Remove an installed version:
         funcvm remove 4.0.3928\n`);
         process.exit(0);
@@ -169,12 +179,12 @@ Examples:
             console.log(`${tag.coreToolsVersion} already installed. Run 'funcvm use ${tag.coreToolsVersion}' or set '${constants.versionEnvironmentVariableName}' environment variable to use it.`);
         }
     }
-    
+
     if (isUseCommand) {
         if (args.includes('--local')) {
-          fs.writeFileSync(path.join(process.cwd(), '.func-version'), tag.coreToolsVersion, 'utf8');
+            fs.writeFileSync(path.join(process.cwd(), '.func-version'), tag.coreToolsVersion, 'utf8');
         } else {
-          fs.writeFileSync(path.join(downloadDir, 'funcvm-core-tools-version.txt'), tag.coreToolsVersion, 'utf8');
+            fs.writeFileSync(path.join(downloadDir, 'funcvm-core-tools-version.txt'), tag.coreToolsVersion, 'utf8');
         }
         console.log(`Using ${tag.coreToolsVersion}`);
     }

--- a/index.js
+++ b/index.js
@@ -36,6 +36,7 @@ async function main() {
     const isInstallCommand = command === 'install' && !!version;
     const isListCommand = command === 'list';
     const isRemoveCommand = command === 'remove';
+    const isFreezeCommand = command === 'freeze';
 
     if (isListCommand) {
         const versions = fs.readdirSync(downloadDir);
@@ -58,6 +59,11 @@ async function main() {
         }
         fs.rmdirSync(versionDir, { recursive: true });
         process.exit(0);
+    } else if (isFreezeCommand) {
+        const versionFile = path.join(downloadDir, 'funcvm-core-tools-version.txt');
+        const localVersionFile = path.join(process.cwd(), '.func-version');
+        fs.copyFileSync(versionFile, localVersionFile);
+        process.exit(0);
     } else if (!isUseCommand && !isInstallCommand) {
         console.log(`
 Azure Functions Core Tools Version Manager (unofficial)
@@ -79,7 +85,10 @@ Examples:
         funcvm list
         
     Remove an installed version:
-        funcvm remove 4.0.3928\n`);
+        funcvm remove 4.0.3928
+
+    Generate \`.func-version\` in current directory:
+        funcvm freeze\n`);
         process.exit(0);
     }
 


### PR DESCRIPTION
1. Change `func` version temporarily if there is `.func-version` in the directory.
2. Generate `.func-veresion` in current directory by ~~`funcvm freeze`~~ `func use ${version} --local`. ~~(just coping from `$HOME/.funcvm/download/funcvm-core-tools-version.txt`)~~
3. Show `global` or `local` in result of `funcvm list`
  ![image](https://user-images.githubusercontent.com/4566555/140428679-d7388996-b63e-45a7-a43b-e7a980ffffb9.png)
