### PR TITLE
feat: add `--remote` option to `list` command for retrieving published versions

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,11 +64,11 @@ async function main() {
                         continue;
                     };
                     const tags = [];
-                    versions.includes(version) && tags.push('installed');
                     process.env[constants.versionEnvironmentVariableName] === version && tags.push('env');
                     localVersion === version && tags.push('local');
                     currentVersion === version && tags.push('global');
                     !versions.includes(version) && tags.length > 0 && tags.push('not installed');
+                    versions.includes(version) && tags.length === 0 && tags.push('installed');
                     releases[version] = `${tags.length > 0 ? ` (${tags.join(', ')})`: ''}`;
                 } catch { }
             }

--- a/index.js
+++ b/index.js
@@ -65,8 +65,10 @@ async function main() {
                     };
                     const tags = [];
                     versions.includes(version) && tags.push('installed');
-                    currentVersion === version && tags.push('global');
+                    process.env[constants.versionEnvironmentVariableName] === version && tags.push('env');
                     localVersion === version && tags.push('local');
+                    currentVersion === version && tags.push('global');
+                    !versions.includes(version) && tags.length > 0 && tags.push('not installed');
                     releases[version] = `${tags.length > 0 ? ` (${tags.join(', ')})`: ''}`;
                 } catch { }
             }
@@ -75,8 +77,9 @@ async function main() {
         }
         for (const version of versions) {
             const tags = [];
-            currentVersion === version && tags.push('global');
+            process.env[constants.versionEnvironmentVariableName] === version && tags.push('env');
             localVersion === version && tags.push('local');
+            currentVersion === version && tags.push('global');
             console.log(`${version}${tags.length > 0 ? ` (${tags.join(', ')})`: ''}`);
         }
         process.exit(0);
@@ -110,6 +113,9 @@ Examples:
 
     List installed versions:
         funcvm list
+
+    List published versions:
+        funcvm list --remote
 
     Remove an installed version:
         funcvm remove 4.0.3928\n`);

--- a/index.js
+++ b/index.js
@@ -52,28 +52,25 @@ async function main() {
         if (args.includes('--remote')) {
             const feedResponse = await fetch("https://aka.ms/AAeq1v7");
             const feed = await feedResponse.json();
-            const releases = [];
-            for (const [release, releaseInfo] of Object.entries(feed.releases)) {
+            const releases = {};
+            for (const [, releaseInfo] of Object.entries(feed.releases).sort()) {
                 const coreTool = releaseInfo.coreTools.find(tools => tools.OS === getPlatform().os);
                 if (!coreTool) {
                     continue;
                 };
                 try {
                     const version = coreTool.downloadLink.match(/\d+\.\d+\.\d+/)[0];
-                    if (releases.find(r => r.version === version)) {
+                    if (releases[version]) {
                         continue;
                     };
                     const tags = [];
                     versions.includes(version) && tags.push('installed');
                     currentVersion === version && tags.push('global');
                     localVersion === version && tags.push('local');
-                    releases.push({
-                        version,
-                        tags: `${tags.length > 0 ? ` (${tags.join(', ')})`: ''}`
-                    })
+                    releases[version] = `${tags.length > 0 ? ` (${tags.join(', ')})`: ''}`;
                 } catch { }
             }
-            console.log(releases.sort((r1, r2) => r1.version >= r2.version ? 1 : -1).map(r => `${r.version}${r.tags}`).join('\n'));
+            console.log(Object.entries(releases).sort((r1, r2) => r1[0] > r2[0] ? 1 : -1).map(r => r.join(' ')).join('\n'));
             process.exit(0);
         }
         for (const version of versions) {


### PR DESCRIPTION
This PR is adding the feature to retrieve published functions-core-tools versions like the following screenshot.
![image](https://user-images.githubusercontent.com/4566555/141089425-170f40ae-5730-47b2-9a01-dc06d36fd0b4.png)


Each label means:
- `env`: specified version by the environment variable `FUNCVM_CORE_TOOLS_VERSION`
- `local`: specified version by `./.func-version`
- `global`: specified version by `$HOME/.funcvm/download/funcvm-core-tools-version.txt`
- `installed`: installed version but not specified by `env`, `local` and `global`
- `not installed` not installed even though specified by `env`, `local` or `global`
- no label: not installed and not specified `env`, `local` and `global`.

I want to discuss this feature, more appropriate labeling, label ordering and etc.